### PR TITLE
add chainlink keepers for claiming streaming fees

### DIFF
--- a/contracts/interfaces/IStreamingFeeSplitExtension.sol
+++ b/contracts/interfaces/IStreamingFeeSplitExtension.sol
@@ -1,0 +1,21 @@
+/*
+    Copyright 2021 IndexCooperative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.6.10;
+
+interface IStreamingFeeSplitExtension {
+    function accrueFeesAndDistribute() external;
+}

--- a/contracts/keepers/FeeClaimKeeper.sol
+++ b/contracts/keepers/FeeClaimKeeper.sol
@@ -1,0 +1,40 @@
+/*
+    Copyright 2021 Index Cooperative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.6.10;
+
+import { IStreamingFeeSplitExtension } from "../interfaces/IStreamingFeeSplitExtension.sol";
+
+contract FeeClaimKeeper {
+
+    mapping(address => uint256) public lastUpkeeps;
+
+    function checkUpkeep(bytes calldata _checkData) external view returns (bool upkeepNeeded, bytes memory performData) {
+
+        (address streamingFeeExtension, uint256 delay) = abi.decode(_checkData, (address, uint256));
+
+        upkeepNeeded = block.timestamp > lastUpkeeps[streamingFeeExtension] + delay;
+        performData = abi.encode(streamingFeeExtension);
+    }
+
+    function performUpkeep(bytes calldata _performData) external {
+
+        address streamingFeeExtension = abi.decode(_performData, (address));
+
+        lastUpkeeps[streamingFeeExtension] = block.timestamp;
+        IStreamingFeeSplitExtension(streamingFeeExtension).accrueFeesAndDistribute();
+    }
+}

--- a/test/keepers/feeClaimKeeper.spec.ts
+++ b/test/keepers/feeClaimKeeper.spec.ts
@@ -1,0 +1,154 @@
+import "module-alias/register";
+
+import { BaseManager, StreamingFeeSplitExtension, FeeClaimKeeper } from "@utils/contracts/index";
+import { SetToken } from "@utils/contracts/setV2";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  ether,
+  getAccounts,
+  getLastBlockTimestamp,
+  getSetFixture,
+  getWaffleExpect,
+} from "@utils/index";
+import { SetFixture } from "@utils/fixtures";
+import { ContractTransaction } from "ethers";
+import { Account } from "@utils/types";
+import { ADDRESS_ZERO, ZERO } from "@utils/constants";
+import { defaultAbiCoder } from "ethers/lib/utils";
+
+const expect = getWaffleExpect();
+
+describe("FeeClaimKeeper", () => {
+
+  let owner: Account;
+  let methodologist: Account;
+  let operator: Account;
+  let setV2Setup: SetFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+
+  let baseManager: BaseManager;
+  let feeExtension: StreamingFeeSplitExtension;
+
+  let feeClaimKeeper: FeeClaimKeeper;
+
+  before(async () => {
+    [
+      owner,
+      methodologist,
+      operator,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSetFixture(owner.address);
+    await setV2Setup.initialize();
+
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address],
+      [ether(1)],
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+    );
+
+    // Deploy BaseManager
+    baseManager = await deployer.manager.deployBaseManager(
+      setToken.address,
+      operator.address,
+      methodologist.address
+    );
+
+    // Deploy streaming fee module
+    const feeRecipient = baseManager.address;
+    const maxStreamingFeePercentage = ether(.1);
+    const streamingFeePercentage = ether(.02);
+    const streamingFeeSettings = {
+      feeRecipient,
+      maxStreamingFeePercentage,
+      streamingFeePercentage,
+      lastStreamingFeeTimestamp: ZERO,
+    };
+    await setV2Setup.streamingFeeModule.initialize(setToken.address, streamingFeeSettings);
+
+    await setV2Setup.issuanceModule.initialize(
+      setToken.address,
+      ADDRESS_ZERO
+    );
+
+    // Deploy streaming fee extension
+    feeExtension = await deployer.adapters.deployStreamingFeeSplitExtension(
+      baseManager.address,
+      setV2Setup.streamingFeeModule.address,
+      ether(0.7)
+    );
+    await baseManager.connect(operator.wallet).addAdapter(feeExtension.address);
+
+    // Transfer ownership of set to baseManager
+    await setToken.setManager(baseManager.address);
+
+    // Mint some sets
+    await setV2Setup.dai.approve(setV2Setup.issuanceModule.address, ether(3));
+    await setV2Setup.issuanceModule.issue(setToken.address, ether(2), owner.address);
+
+    // Deploy keeper
+    feeClaimKeeper = await deployer.keepers.deployFeeClaimKeeper();
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#checkUpkeep", async () => {
+
+    let subjectCheckData: string;
+
+    beforeEach(() => {
+      subjectCheckData = defaultAbiCoder.encode(["address", "uint256"], [feeExtension.address, 60 * 60 * 24]);
+    });
+
+    async function subject(): Promise<[boolean, string]> {
+      return await feeClaimKeeper.checkUpkeep(subjectCheckData);
+    }
+
+    it("should return true for upkeepNeeded and encode the correct streaming fee extension to call", async () => {
+      const [ upkeepNeeded, performData ] = await subject();
+
+      expect(upkeepNeeded).to.be.true;
+      expect(performData).to.eq(defaultAbiCoder.encode(["address"], [feeExtension.address]));
+    });
+  });
+
+  describe("#performUpkeep", async () => {
+
+    let subjectPerformData: string;
+
+    beforeEach(() => {
+      subjectPerformData = defaultAbiCoder.encode(["address"], [feeExtension.address]);
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return await feeClaimKeeper.performUpkeep(subjectPerformData);
+    }
+
+    it("should claim fees", async () => {
+      const initOperatorSetBalance = await setToken.balanceOf(operator.address);
+      const initMethodologistSetBalance = await setToken.balanceOf(methodologist.address);
+
+      await subject();
+
+      const finalOperatorSetBalance = await setToken.balanceOf(operator.address);
+      const finalMethodologistSetBalance = await setToken.balanceOf(methodologist.address);
+
+      expect(finalOperatorSetBalance.gt(initOperatorSetBalance)).to.be.true;
+      expect(finalMethodologistSetBalance.gt(initMethodologistSetBalance)).to.be.true;
+    });
+
+    it("should update the lastUpkeeps value for the extension", async () => {
+      await subject();
+
+      const lastUpkeep = await feeClaimKeeper.lastUpkeeps(feeExtension.address);
+      const expectedLastUpkeep = await getLastBlockTimestamp();
+
+      expect(lastUpkeep).to.eq(expectedLastUpkeep);
+    });
+  });
+});

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -3,6 +3,7 @@ export { BaseManager } from "../../typechain/BaseManager";
 export { ChainlinkAggregatorV3Mock } from "../../typechain/ChainlinkAggregatorV3Mock";
 export { ExchangeIssuance } from "../../typechain/ExchangeIssuance";
 export { ExchangeIssuanceV2 } from "../../typechain/ExchangeIssuanceV2";
+export { FeeClaimKeeper } from "../../typechain/FeeClaimKeeper";
 export { FeeSplitAdapter } from "../../typechain/FeeSplitAdapter";
 export { FlexibleLeverageStrategyExtension } from "../../typechain/FlexibleLeverageStrategyExtension";
 export { GIMExtension } from "../../typechain/GIMExtension";

--- a/utils/deploys/deployKeepers.ts
+++ b/utils/deploys/deployKeepers.ts
@@ -11,7 +11,7 @@ export default class DeployKeepers {
     this._deployerSigner = deployerSigner;
   }
 
-  public async deployFeeClaimKeeper(): Promise<FeeClaimKeeper> {
-    return await new FeeClaimKeeper__factory(this._deployerSigner).deploy();
+  public async deployFeeClaimKeeper(gasPriceFeed: string): Promise<FeeClaimKeeper> {
+    return await new FeeClaimKeeper__factory(this._deployerSigner).deploy(gasPriceFeed);
   }
 }

--- a/utils/deploys/deployKeepers.ts
+++ b/utils/deploys/deployKeepers.ts
@@ -1,0 +1,17 @@
+import { Signer } from "ethers";
+
+import { FeeClaimKeeper } from "../contracts/index";
+
+import { FeeClaimKeeper__factory } from "../../typechain/factories/FeeClaimKeeper__factory";
+
+export default class DeployKeepers {
+  private _deployerSigner: Signer;
+
+  constructor(deployerSigner: Signer) {
+    this._deployerSigner = deployerSigner;
+  }
+
+  public async deployFeeClaimKeeper(): Promise<FeeClaimKeeper> {
+    return await new FeeClaimKeeper__factory(this._deployerSigner).deploy();
+  }
+}

--- a/utils/deploys/index.ts
+++ b/utils/deploys/index.ts
@@ -9,6 +9,7 @@ import DeployExternalContracts from "./deployExternal";
 import DeployHooks from "./deployHooks";
 import DeployStaking from "./deployStaking";
 import DeployViewers from "./deployViewers";
+import DeployKeepers from "./deployKeepers";
 
 export default class DeployHelper {
   public token: DeployToken;
@@ -20,6 +21,7 @@ export default class DeployHelper {
   public hooks: DeployHooks;
   public staking: DeployStaking;
   public viewers: DeployViewers;
+  public keepers: DeployKeepers;
 
   constructor(deployerSigner: Signer) {
     this.token = new DeployToken(deployerSigner);
@@ -31,5 +33,6 @@ export default class DeployHelper {
     this.hooks = new DeployHooks(deployerSigner);
     this.staking = new DeployStaking(deployerSigner);
     this.viewers = new DeployViewers(deployerSigner);
+    this.keepers = new DeployKeepers(deployerSigner);
   }
 }


### PR DESCRIPTION
The treasury committee has been asking about automating fee claims a lot lately. This could have probably been more easily done with a node script or a  defender autotask, but I figured I'd get some practice with chainlink keepers if we are going to be using them in the future more.

Here's the keeper in action on kovan:
https://kovan.etherscan.io/address/0x26984f581ff8decd263713ab7904b1cb5d42af2e#internaltx
You need to look at the internal transactions to see the calls since they get routed through another contract. This one is set to claim the fees every 3 minutes.