### PR TITLE
Flash mint contract for wrapped tokens

### DIFF
--- a/contracts/exchangeIssuance/FlashMintWrapped.sol
+++ b/contracts/exchangeIssuance/FlashMintWrapped.sol
@@ -1,0 +1,236 @@
+/*
+    Copyright 2022 Index Cooperative
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+pragma experimental ABIEncoderV2;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/math/Math.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import { IController } from "../interfaces/IController.sol";
+import { IDebtIssuanceModule } from "../interfaces/IDebtIssuanceModule.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+import { IWETH } from "../interfaces/IWETH.sol";
+import { PreciseUnitMath } from "../lib/PreciseUnitMath.sol";
+
+/**
+ * @title FlashMintWrapped
+ *
+ * Flash issues SetTokens whose components are purely made up of wrapped tokens.
+ * In particular, for issuance, the contract needs to:
+ * 1. For all components in a SetToken, swap input token into matching unwrapped component
+ * 2. For each unwrapped component, execute the wrapping function
+ * 3. Call on issuanceModule to issue tokens
+ */
+contract FlashMintWrapped is ReentrancyGuard {
+
+    using Address for address payable;
+    using SafeMath for uint256;
+    using PreciseUnitMath for uint256;
+    using SafeERC20 for IERC20;
+    using SafeERC20 for ISetToken;
+
+    struct WrappedCalldata {
+        address target;
+        uint256 quantity;
+        bytes callData;
+    }
+
+    /* ============ Enums ============ */
+
+    /* ============ Constants ============= */
+
+    uint256 constant private MAX_UINT96 = 2**96 - 1;
+    address constant public ETH_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    /* ============ State Variables ============ */
+
+    IController public immutable controller;
+
+    /* ============ Events ============ */
+
+    event ExchangeIssue(
+        address indexed _recipient,     // The recipient address of the issued SetTokens
+        ISetToken indexed _setToken,    // The issued SetToken
+        IERC20 indexed _inputToken,     // The address of the input asset(ERC20/ETH) used to issue the SetTokens
+        uint256 _amountInputToken,      // The amount of input tokens used for issuance
+        uint256 _amountSetIssued        // The amount of SetTokens received by the recipient
+    );
+
+    event ExchangeRedeem(
+        address indexed _recipient,     // The recipient address which redeemed the SetTokens
+        ISetToken indexed _setToken,    // The redeemed SetToken
+        IERC20 indexed _outputToken,    // The address of output asset(ERC20/ETH) received by the recipient
+        uint256 _amountSetRedeemed,     // The amount of SetTokens redeemed for output tokens
+        uint256 _amountOutputToken      // The amount of output tokens received by the recipient
+    );
+
+    /* ============ Modifiers ============ */
+
+    modifier isSetToken(ISetToken _setToken) {
+        require(controller.isSet(address(_setToken)), "ExchangeIssuance: INVALID SET");
+        _;
+    }
+
+    modifier isValidModule(address _issuanceModule) {
+        require(controller.isModule(_issuanceModule), "ExchangeIssuance: INVALID ISSUANCE MODULE");
+        _;
+    }
+
+    /* ========== Constructor ========== */
+
+    constructor(address _controller) {
+       controller = IController(_controller);
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * Runs all the necessary approval functions required for a given ERC20 token.
+     * This function can be called when a new token is added to a SetToken during a
+     * rebalance.
+     *
+     * @param _token    Address of the token which needs approval
+     * @param _spender  Address of the spender which will be approved to spend token. (Must be a whitlisted issuance module)
+     */
+    function approveToken(IERC20 _token, address _spender) external isValidModule(_spender) {
+    }
+
+    /**
+     * Runs all the necessary approval functions required for a list of ERC20 tokens.
+     *
+     * @param _tokens    Addresses of the tokens which need approval
+     * @param _spender   Address of the spender which will be approved to spend token. (Must be a whitlisted issuance module)
+     */
+    function approveTokens(IERC20[] calldata _tokens, address _spender) external {
+    }
+
+    /**
+     * Runs all the necessary approval functions required before issuing
+     * or redeeming a SetToken. This function need to be called only once before the first time
+     * this smart contract is used on any particular SetToken.
+     *
+     * @param _setToken          Address of the SetToken being initialized
+     * @param _issuanceModule    Address of the issuance module which will be approved to spend component tokens.
+     */
+    function approveSetToken(ISetToken _setToken, address _issuanceModule) external {
+    }
+
+    /**
+    * Issues an exact amount of SetTokens for given amount of input ERC20 tokens.
+    * The excess amount of tokens is returned in an equivalent amount of ether.
+    *
+    * @param _setToken              Address of the SetToken to be issued
+    * @param _inputToken            Address of the input token
+    * @param _amountSetToken        Amount of SetTokens to issue
+    * @param _calldata              The calldata needed to execute all the wrapping of tokens
+    *
+    * @return totalInputTokenSold   Amount of input token spent for issuance
+    */
+    function issueExactSetFromToken(
+        ISetToken _setToken,
+        IERC20 _inputToken,
+        uint256 _amountSetToken,
+        WrappedCalldata[] memory _calldata
+    )
+    external
+    nonReentrant
+    returns (uint256)
+    {
+        return 0;
+    }
+
+
+    /**
+    * Issues an exact amount of SetTokens for given amount of ETH.
+    * The excess amount of tokens is returned in an equivalent amount of ether.
+    *
+    * @param _setToken              Address of the SetToken to be issued
+    * @param _amountSetToken        Amount of SetTokens to issue
+    * @param _componentQuotes       The encoded 0x transactions to execute
+    *
+    * @return amountEthReturn       Amount of ether returned to the caller
+    */
+    function issueExactSetFromETH(
+        ISetToken _setToken,
+        uint256 _amountSetToken
+    )
+    external
+    nonReentrant
+    payable
+    returns (uint256)
+    {
+        return 0;
+    }
+
+    /**
+     * Redeems an exact amount of SetTokens for an ERC20 token.
+     * The SetToken must be approved by the sender to this contract.
+     *
+     * @param _setToken             Address of the SetToken being redeemed
+     * @param _outputToken          Address of output token
+     * @param _amountSetToken       Amount SetTokens to redeem
+     * @param _minOutputReceive     Minimum amount of output token to receive
+     * @param _componentQuotes      The encoded 0x transactions execute (components -> WETH).
+     * @param _issuanceModule       Address of issuance Module to use
+     * @param _isDebtIssuance       Flag indicating wether given issuance module is a debt issuance module
+     *
+     * @return outputAmount         Amount of output tokens sent to the caller
+     */
+    function redeemExactSetForToken(
+        ISetToken _setToken,
+        IERC20 _outputToken,
+        uint256 _amountSetToken,
+        uint256 _minOutputReceive,
+        address _issuanceModule
+    )
+    external
+    nonReentrant
+    returns (uint256)
+    {
+        return 0;
+    }
+
+    /**
+     * Redeems an exact amount of SetTokens for ETH.
+     * The SetToken must be approved by the sender to this contract.
+     *
+     * @param _setToken             Address of the SetToken being redeemed
+     * @param _amountSetToken       Amount SetTokens to redeem
+     * @param _minEthReceive        Minimum amount of Eth to receive
+     * @param _componentQuotes      The encoded 0x transactions execute
+     * @param _issuanceModule       Address of issuance Module to use
+     * @param _isDebtIssuance       Flag indicating wether given issuance module is a debt issuance module
+     *
+     * @return outputAmount         Amount of output tokens sent to the caller
+     */
+    function redeemExactSetForETH(
+        ISetToken _setToken,
+        uint256 _amountSetToken,
+        uint256 _minEthReceive,
+        address _issuanceModule
+    )
+    external
+    nonReentrant
+    returns (uint256)
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
Passing thoughts on implementing this flash mint contract:
1. The initial product only requires wrapping and unwrapping compound tokens (CMI)
2. However there are plans to extend products to Aave, Balancer and other protocols that require wrapping and unwrapping tokens. All these wrapping and unwrapping contract calls are all slightly different.
3. Not only do we need to wrap and unwrap tokens, we need to also purchase the tokens on exchange as well.
4. Need to fulfil these requirements in a gas-efficient and secure way.
Hence, the design needs to be extendable to both future wrapping defi protocols, and then future exchanges.

So in the params - I want to allow the client to:
1. pass in the encoded function calls to purchase the tokens on the exchange (similar to ExchangeIssuanceZeroEx)
2. pass in the encoded function calls to wrap/unwrap the tokens (we don't have this, but this function call data can be encoded off-chain)

Because these encoded function calls are bytes - how do we validate these contract calls?

Open questions:
1. Will there be dust left in the contract? Do we need a withdraw method?
2. Will estimateGas still work?