### PR TITLE
PNM Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   checkout_and_compile:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     steps:
       - checkout
@@ -33,7 +33,7 @@ jobs:
             - ~/index-coop-smart-contracts
   test:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     parallelism: 2
     steps:
@@ -60,7 +60,7 @@ jobs:
 
   test_integration_polygon:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     steps:
       - setup_remote_docker:
@@ -83,7 +83,7 @@ jobs:
 
   test_integration_optimism:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     steps:
       - setup_remote_docker:
@@ -106,7 +106,7 @@ jobs:
 
   test_integration_ethereum:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     steps:
       - setup_remote_docker:
@@ -129,7 +129,7 @@ jobs:
 
   coverage:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     parallelism: 2
     steps:
@@ -166,7 +166,7 @@ jobs:
 
   report_coverage:
     docker:
-      - image: cimg/node:lts
+      - image: cimg/node:16.18
     working_directory: ~/index-coop-smart-contracts
     steps:
       - attach_workspace:

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.1.0",
+    "@pwnednomore/contracts": "^0.2.9",
     "@typechain/ethers-v5": "^5.0.0",
     "@types/chai": "^4.2.11",
     "@types/fs-extra": "^5.0.0",

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,3 @@
-@pwnednomore/contracts/=node_modules/@pwnednomore/contracts/
+@pwnednomore/=node_modules/@pwnednomore/
+ds-test/=node_modules/@pwnednomore/contracts/lib/forge-std/lib/ds-test/src/
+forge-std/=node_modules/@pwnednomore/contracts/lib/forge-std/src/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+@pwnednomore/contracts/=node_modules/@pwnednomore/contracts/

--- a/test/pnm/PnmTest.t.sol
+++ b/test/pnm/PnmTest.t.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.6.10;
+
+import "@pwnednomore/contracts/PTest.sol";
+
+contract StructTest is PTest {
+    uint256 testNumber;
+
+    function setUp() public {
+        testNumber = 42;
+    }
+
+    function invariantFlagIsTrue() public view {
+        assert(testNumber == 42);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.3.0.tgz#ffdb693c5c349fc33bba420248dd3ac0a2d7c408"
   integrity sha512-AemZEsQYtUp1WRkcmZm1div5ORfTpLquLaziCIrSagjxyKdmObxuaY1yjQ5SHFMctR8rLwp706NXTbiIRJg7pw==
 
+"@pwnednomore/contracts@^0.2.9":
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/@pwnednomore/contracts/-/contracts-0.2.9.tgz#163a96f534c9482ddef0769b636718f6b0d20282"
+  integrity sha512-ldcDa15DS5LYcBXhn9fF11H/ovlsV9m+IdEObjYMB+kQwfyAQXnxYM+1NYO21exsdXeBruit33sKD1xo2htICg==
+
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@resolver-engine/core/-/core-0.3.3.tgz#590f77d85d45bc7ecc4e06c654f41345db6ca967"


### PR DESCRIPTION
Setting up PNM Test integration. The initial test only tests that a number is always 42.

The plan is to merge this. Delete this branch and then open up a new branch named `pnm-tests`. So far, pnm only monitors a branch called pnm-tests.