### PR TITLE
Extended `minPositions` configuration to potentially allow opening up access to `rebalance` method

### DIFF
--- a/contracts/adapters/FixedRebalanceExtension.sol
+++ b/contracts/adapters/FixedRebalanceExtension.sol
@@ -55,7 +55,7 @@ contract FixedRebalanceExtension is BaseExtension {
 
     uint256[] internal maturities;                               // Array of relative maturities in seconds (i.e. 3 months / 6 months)
     uint256[] internal allocations;                              // Relative allocations 
-    uint256[] internal minPositions;                             // Minimum positions to achieve after rebalancing
+    uint256[] internal minPositions;                             // Minimum positions to achieve after every full rebalancing (assuming share = 100 %)
 
     ISetToken public immutable setToken;                       
     INotionalTradeModule internal immutable notionalTradeModule; 
@@ -119,16 +119,17 @@ contract FixedRebalanceExtension is BaseExtension {
     /**
      * ONLY ALLOWED CALLER: Rebalances the positions towards the configured allocation percentages.
      *
-     * @param _share                Relative share of the necessary trade volume to execute (allows for splitting the rebalance over multiple transactions
-     * @param _minPositions         Minimum positions (in set token units) for each maturity after rebalance. (slippage protection)
+     * @param _share                 Relative share of the necessary trade volume to execute (allows for splitting the rebalance over multiple transactions
+     * @param _rebalanceMinPositions Minimum positions (in set token units) for each maturity after this rebalance operation. 
+     * @dev Will revert if _rebalanceMinPositions is lower than the minPositions configured by the operator (weighted by share)
      */
-    function rebalance(uint256 _share, uint256[] memory _minPositions) external onlyAllowedCaller(msg.sender) {
+    function rebalance(uint256 _share, uint256[] memory _rebalanceMinPositions) external onlyAllowedCaller(msg.sender) {
         require(_share > 0, "Share must be greater than 0");
         require(_share <= 1 ether, "Share cannot exceed 100%");
 
         uint256[] memory currentPositionsBefore = _sellOverweightPositions(_share);
         _buyUnderweightPositions(_share);
-        _checkCurrentPositions(currentPositionsBefore, _minPositions, _share);
+        _checkCurrentPositions(currentPositionsBefore, _rebalanceMinPositions, _share);
     }
 
     // Aggregates all fCash positions + asset token position into a single value
@@ -160,6 +161,23 @@ contract FixedRebalanceExtension is BaseExtension {
     function relativeToAbsoluteMaturity(uint256 _relativeMaturity) external view returns (uint256) {
         return _relativeToAbsoluteMaturity(_relativeMaturity);
     }
+
+    // Return current token position for each maturity;
+    function getCurrentPositions()
+        external
+        view
+        returns(uint256[] memory currentPositions)
+    {
+        currentPositions = new uint256[](maturities.length);
+        for(uint i = 0; i < maturities.length; i++) {
+            uint256 maturity = _relativeToAbsoluteMaturity(maturities[i]);
+            address wrappedfCash = wrappedfCashFactory.computeAddress(currencyId, uint40(maturity));
+            int256 currentPositionSigned = setToken.getDefaultPositionRealUnit(wrappedfCash);
+            require(currentPositionSigned >= 0, "Negative position");
+            currentPositions[i] = uint256(currentPositionSigned);
+        }
+    }
+
 
 
 
@@ -199,45 +217,36 @@ contract FixedRebalanceExtension is BaseExtension {
         }
     }
 
-    function _checkCurrentPositions(uint256[] memory _positionsBefore, uint256[] memory _minPositions, uint256 _share)
+    // @dev Checks that the positions after rebalance are above the _rebalanceMinPositions specified in rebalanceCall
+    // @dev Also verifies that _rebalanceMinPositions are above the minPositions configured by the operator (weighted by _share)
+    function _checkCurrentPositions(uint256[] memory _positionsBefore, uint256[] memory _rebalanceMinPositions, uint256 _share)
         internal
         view
     {
-        require(_minPositions.length == maturities.length , "Min positions must be same length as maturities");
+        require(_rebalanceMinPositions.length == maturities.length , "Min positions must be same length as maturities");
         for(uint i = 0; i < maturities.length; i++) {
 
-            uint256 weightedMinPosition;
-            if(minPositions[i] > _positionsBefore[i]) {
-                // If the position was below the min position before you have to increase it by at least _share % of the difference
-                weightedMinPosition = _positionsBefore[i].add(minPositions[i].sub(_positionsBefore[i]).preciseMul(_share));
-            } else {
-                // If the position was above the min position before you can only decrease it by maximum _share % of the difference
-                weightedMinPosition = _positionsBefore[i].sub(_positionsBefore[i].sub(minPositions[i]).preciseMul(_share));
-            } 
-
-            require(_minPositions[i] >= weightedMinPosition, "Caller provided min position must not be less than operator specified value weighted by share");
+            uint256 weightedMinPosition = _getWeightedMinPosition(minPositions[i], _positionsBefore[i], _share);
+            require(_rebalanceMinPositions[i] >= weightedMinPosition, "Caller provided min position must not be less than operator specified value weighted by share");
             uint256 maturity = _relativeToAbsoluteMaturity(maturities[i]);
             address wrappedfCash = wrappedfCashFactory.computeAddress(currencyId, uint40(maturity));
             int256 currentPositionSigned = setToken.getDefaultPositionRealUnit(wrappedfCash);
             require(currentPositionSigned >= 0, "Negative position");
-            require(uint256(currentPositionSigned) >= _minPositions[i], "Position below min");
+            require(uint256(currentPositionSigned) >= _rebalanceMinPositions[i], "Position below min");
         }
     }
 
-    function getCurrentPositions()
-        external
-        view
-        returns(uint256[] memory currentPositions)
-    {
-        currentPositions = new uint256[](maturities.length);
-        for(uint i = 0; i < maturities.length; i++) {
-            uint256 maturity = _relativeToAbsoluteMaturity(maturities[i]);
-            address wrappedfCash = wrappedfCashFactory.computeAddress(currencyId, uint40(maturity));
-            int256 currentPositionSigned = setToken.getDefaultPositionRealUnit(wrappedfCash);
-            require(currentPositionSigned >= 0, "Negative position");
-            currentPositions[i] = uint256(currentPositionSigned);
-        }
+    // @dev Calculates the minimumPosition for a given maturity by taking the weighted average between the _minPosition configured by the operator and the position before the rebalance call.
+    function _getWeightedMinPosition(uint256 _minPosition, uint256 _positionBefore, uint256 _share) internal pure returns(uint256) {
+        if(_minPosition > _positionBefore) {
+            // If the position was below the min position before you have to increase it by at least _share % of the difference
+            return _positionBefore.add(_minPosition.sub(_positionBefore).preciseMul(_share));
+        } else {
+            // If the position was above the min position before you can only decrease it by maximum _share % of the difference
+            return _positionBefore.sub(_positionBefore.sub(_minPosition).preciseMul(_share));
+        } 
     }
+
 
     // @dev Get positions that are currently above their targeted weight
     function _getOverweightPositions()

--- a/test/integration/ethereum/fixedRebalanceExtension.spec.ts
+++ b/test/integration/ethereum/fixedRebalanceExtension.spec.ts
@@ -72,7 +72,7 @@ if (process.env.INTEGRATIONTEST) {
       );
 
       componentMaturities = await Promise.all(
-        (await setToken.getComponents()).map((c) => {
+        (await setToken.getComponents()).map(c => {
           const wrappedfCash = IWrappedfCashComplete__factory.connect(c, operator);
           return wrappedfCash.getMaturity();
         }),
@@ -124,14 +124,14 @@ if (process.env.INTEGRATIONTEST) {
         let assetTokenContract: IERC20;
         let threeMonthAllocation: BigNumber;
         let sixMonthAllocation: BigNumber;
-        let minPositions = [parseUnits("20", 8), parseUnits("20", 8)];
+        const minPositions = [parseUnits("20", 8), parseUnits("20", 8)];
 
         beforeEach(async () => {
           underlyingToken = addresses.tokens.dai;
           assetToken = addresses.tokens.cDAI;
           assetTokenContract = IERC20__factory.connect(assetToken, operator);
           const maturitiesMonths = [3, 6];
-          maturities = maturitiesMonths.map((m) => ONE_MONTH_IN_SECONDS.mul(m));
+          maturities = maturitiesMonths.map(m => ONE_MONTH_IN_SECONDS.mul(m));
           sixMonthAllocation = ether(0.75);
           threeMonthAllocation = ether(0.25);
           allocations = [threeMonthAllocation, sixMonthAllocation];
@@ -169,7 +169,7 @@ if (process.env.INTEGRATIONTEST) {
         describe("#setAllocations", () => {
           let subjectMaturities: BigNumberish[];
           let subjectAllocations: BigNumberish[];
-          let subjectMinPositions = minPositions;
+          const subjectMinPositions = minPositions;
           let caller: Signer;
           beforeEach(() => {
             subjectMaturities = [ONE_MONTH_IN_SECONDS.mul(6), ONE_MONTH_IN_SECONDS.mul(3)];
@@ -358,7 +358,7 @@ if (process.env.INTEGRATIONTEST) {
               });
             });
 
-            [false, true].forEach((tradeViaUnderlying) => {
+            [false, true].forEach(tradeViaUnderlying => {
               describe(`When trading via the ${
                 tradeViaUnderlying ? "underlying" : "asset"
               } token`, () => {
@@ -498,24 +498,23 @@ if (process.env.INTEGRATIONTEST) {
                       subjectMinPositions = currentPositions.map((curPosition, i) => {
                         const minPosition = minPositions[i];
                         let weightedDiff;
+                        let weightedMinPosition;
                         if (curPosition.gt(minPosition)) {
-                          let weightedMinPosition;
                           weightedDiff = curPosition
                             .sub(minPosition)
                             .mul(subjectShare)
                             .div(ether(1));
 
                           weightedMinPosition = curPosition.sub(weightedDiff);
-                          return weightedMinPosition;
                         } else {
                           weightedDiff = minPosition
                             .sub(curPosition)
                             .mul(subjectShare)
                             .div(ether(1));
 
-                          let weightedMinPosition = curPosition.add(weightedDiff);
-                          return weightedMinPosition;
+                          weightedMinPosition = curPosition.add(weightedDiff);
                         }
+                        return weightedMinPosition;
                       });
                     });
                     it("should adjust the allocations correctly", async () => {

--- a/utils/deploys/deployExtensions.ts
+++ b/utils/deploys/deployExtensions.ts
@@ -418,6 +418,7 @@ export default class DeployExtensions {
     assetToken: Address,
     maturities: BigNumberish[],
     allocations: BigNumberish[],
+    minPositions: BigNumberish[],
   ) {
     return new FixedRebalanceExtension__factory(this._deployerSigner).deploy(
       manager,
@@ -429,6 +430,7 @@ export default class DeployExtensions {
       assetToken,
       maturities,
       allocations,
+        minPositions,
     );
   }
 }


### PR DESCRIPTION
This PR splits up the configuration of the minimum positions to reach after the rebalance call into two parts:

`_rebalanceMinPositions`: Values passed by the caller to `rebalance` to provide slippage protection.
`minPositions`: State variable controlled by the "operator" used to verify lower bound of `_rebalanceMinPositions`. Each element in `_rebalanceMinPositions` has to be greater or equal to the weighted (by `_share`) average between the operator specified minPosition and the position prior to the rebalance call.

Note that when `minPositions` is specified to all zeroes the functionality should remain largely unchanged and the caller can specify arbitrary `_rebalanceMinPositions`.

Sensibly configuring  `minPositions` should provide an additional layer of security against malicious calls of `rebalance` (for example if private key of another 'allowedCaller' is compromised).
It might even enable making the `rebalance` method publicly callable, although this should be decided on with extreme caution.