### PR TITLE
Fix error in curve integration of ExchangeIssuanceLeveraged

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: copy env
         run: cp .env.default .env
       - name: install

--- a/contracts/exchangeIssuance/DEXAdapter.sol
+++ b/contracts/exchangeIssuance/DEXAdapter.sol
@@ -429,6 +429,9 @@ library DEXAdapter {
         );
         require(amountIn <= _maxAmountIn, "ExchangeIssuance: CURVE_OVERSPENT");
 
+        require(ICurvePool(_pool).get_dy(i, j, amountIn) >= _amountOut, "ExchangeIssuance: amountIn too low");
+
+
         if(_path[0] == ETH_ADDRESS){
             IWETH(_addresses.weth).withdraw(amountIn);
         }

--- a/contracts/exchangeIssuance/DEXAdapter.sol
+++ b/contracts/exchangeIssuance/DEXAdapter.sol
@@ -437,7 +437,7 @@ library DEXAdapter {
         }
 
         if(_path[_path.length-1] == ETH_ADDRESS){
-            IWETH(_addresses.weth).deposit{ value: returnedAmountOut }();
+            IWETH(_addresses.weth).deposit{ value: _amountOut }();
         }
 
         return _maxAmountIn.sub(swappedBackAmountIn);

--- a/contracts/exchangeIssuance/DEXAdapter.sol
+++ b/contracts/exchangeIssuance/DEXAdapter.sol
@@ -420,30 +420,27 @@ library DEXAdapter {
         require(_path.length == 2, "ExchangeIssuance: CURVE_WRONG_PATH_LENGTH");
         (int128 i, int128 j) = _getCoinIndices(_pool, _path[0], _path[1], ICurveAddressProvider(_addresses.curveAddressProvider));
 
-        uint256 amountIn = _getAmountInCurve(
-            _pool,
-            i,
-            j,
-            _amountOut,
-            _addresses
-        );
-        require(amountIn <= _maxAmountIn, "ExchangeIssuance: CURVE_OVERSPENT");
-
-        require(ICurvePool(_pool).get_dy(i, j, amountIn) >= _amountOut, "ExchangeIssuance: amountIn too low");
-
 
         if(_path[0] == ETH_ADDRESS){
-            IWETH(_addresses.weth).withdraw(amountIn);
+            IWETH(_addresses.weth).withdraw(_maxAmountIn);
         }
 
-        uint256 returnedAmountOut = _exchangeCurve(i, j, _pool, amountIn, _amountOut, _path[0]);
+        uint256 returnedAmountOut = _exchangeCurve(i, j, _pool, _maxAmountIn, _amountOut, _path[0]);
         require(_amountOut <= returnedAmountOut, "ExchangeIssuance: CURVE_UNDERBOUGHT");
+
+        uint256 swappedBackAmountIn;
+        if(returnedAmountOut > _amountOut){
+            swappedBackAmountIn = _exchangeCurve(j, i, _pool, returnedAmountOut.sub(_amountOut), 0, _path[1]);
+            if(_path[0] == ETH_ADDRESS){
+                IWETH(_addresses.weth).deposit{ value: swappedBackAmountIn }();
+            }
+        }
 
         if(_path[_path.length-1] == ETH_ADDRESS){
             IWETH(_addresses.weth).deposit{ value: returnedAmountOut }();
         }
 
-        return amountIn;
+        return _maxAmountIn.sub(swappedBackAmountIn);
     }
     
     function _exchangeCurve(


### PR DESCRIPTION
Problem:
The main issue we face when using curve is the fact that they don't have a "exactOutput" swap. 
In the past we have used the CurveCalculator to determine the equivalent input amount from the requested output.
While this always had some minor imprecision, we were able to just add a few wei of "rounding" error on top to ensure successfull transactions.

Lately however the difference has grown by many orders of magnitudes (from a few wei to fractions of a percent of the total amount). 

Solution:
This smart contract change switches from using the CurveCalculator to just swapping all of the "maxInput" amount of tokens and then swapping the overbought amount back into the input token to achieve the effect of buying a fixed amount of output tokens. 
This is of course quite a bit more gas intensive but does bypass the whole issue with the CurveCalculator.

Open Issue:
-The "quote" method that is used by the frontend to get the required input amount has not been adjusted. There are a few ways around this:
a. Just add a small percentage of "slippage" on top of the quoted amount when issuing iceth
b. Static call the issue method using a tenderly fork or something from an impersonated address that has all of the funds necessary to execute the issuance
c. Adjust the quote method to maybe use an iterative method based on the `get_dx` function of the curve pool to approximate a better input estimation
(In this case gas costs are not really relevant since the quote method is only ever called statically)