### PR TITLE
Update AaveLeverageStrategyExtension.sol: Useless initialization

### DIFF
--- a/contracts/adapters/AaveLeverageStrategyExtension.sol
+++ b/contracts/adapters/AaveLeverageStrategyExtension.sol
@@ -235,7 +235,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
         execution = _execution;
         incentive = _incentive;
 
-        for (uint256 i = 0; i < _exchangeNames.length; i++) {
+        for (uint256 i; i < _exchangeNames.length; i++) {
             _validateExchangeSettings(_exchangeSettings[i]);
             exchangeSettings[_exchangeNames[i]] = _exchangeSettings[i];
             enabledExchanges.push(_exchangeNames[i]);
@@ -247,7 +247,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
     /* ============ External Functions ============ */
 
     /**
-     * OPERATOR ONLY: Engage to target leverage ratio for the first time. SetToken will borrow debt position from Aave and trade for collateral asset. If target
+     * OPERATOR ONLY: Engage to target leverage ratio for the first time. SetToken will borrow debt position from Aave and trade for collateral assets. If target
      * leverage ratio is above max borrow or max trade size, then TWAP is kicked off. To complete engage if TWAP, any valid caller must call iterateRebalance until target
      * is met.
      *
@@ -496,7 +496,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
 
     /**
      * OPERATOR ONLY: Add a new enabled exchange for trading during rebalances. New exchanges will have their exchangeLastTradeTimestamp set to 0. Adding
-     * exchanges during rebalances is allowed, as it is not possible to enter an unexpected state while doing so.
+     * exchanges during rebalances are allowed, as it is not possible to enter an unexpected state while doing so.
      *
      * @param _exchangeName         Name of the exchange
      * @param _exchangeSettings     Struct containing exchange parameters
@@ -590,7 +590,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
 
     /**
      * Get current leverage ratio. Current leverage ratio is defined as the USD value of the collateral divided by the USD value of the SetToken. Prices for collateral
-     * and borrow asset are retrieved from the Chainlink Price Oracle.
+     * and borrow assets are retrieved from the Chainlink Price Oracle.
      *
      * return currentLeverageRatio         Current leverage ratio in precise units (10e18)
      */
@@ -640,7 +640,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
 
         sizes = new uint256[](_exchangeNames.length);
 
-        for (uint256 i = 0; i < _exchangeNames.length; i++) {
+        for (uint256 i; i < _exchangeNames.length; i++) {
     
             LeverageInfo memory leverageInfo = LeverageInfo({
                 action: actionInfo,
@@ -1242,7 +1242,7 @@ contract AaveLeverageStrategyExtension is BaseExtension {
 
         ShouldRebalance[] memory shouldRebalanceEnums = new ShouldRebalance[](enabledExchanges.length);
 
-        for (uint256 i = 0; i < enabledExchanges.length; i++) {
+        for (uint256 i; i < enabledExchanges.length; i++) {
             // If none of the below conditions are satisfied, then should not rebalance
             shouldRebalanceEnums[i] = ShouldRebalance.NONE;
 


### PR DESCRIPTION
In these loops as we saw the lines `for (uint256 i = 0; i < _exchangenames.length; i++)`, this initialization of `uint256 i = 0` is really not needed, we can use just `uint256 i` because the default value of any 'uint' or 'int' is always 0, thus it saves extra gas which gets used up in initialization of that 'i' to 0.

Moreover I also feel that if we changed these lines -> `for(uint256 i; i < _exchangenames.length; i++)` to `for(uint256 i; i < _exchangenames.length; ++i)`, then there won't be any issue in the working of contract and it will save even more gas, You can try this in any remix console by making a demo contract. Although, I didn't including this in PR, but please look at it. If it passes, I am ready to make these changes!!

And, while I was making some changes in this file, I noticed a word `delever` lot of times during comments. I really doubt that it should be `deliver` (just talking about comments part). Please let me know