### PR TITLE
Save ipfs rules hash as string instead of bytes32

### DIFF
--- a/contracts/adapters/OptimisticAuctionRebalanceExtensionV1.sol
+++ b/contracts/adapters/OptimisticAuctionRebalanceExtensionV1.sol
@@ -49,7 +49,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
         IERC20 indexed setToken,
         address indexed manager,
         OptimisticRebalanceParams optimisticParams,
-        bytes32 indexed rulesHash
+        string rulesHash
     );
 
     event RebalanceProposed(
@@ -66,7 +66,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
     event AssertedClaim(
         IERC20 indexed setToken,
         address indexed _assertedBy,
-        bytes32 indexed rulesHash,
+        string rulesHash,
         bytes32 _assertionId,
         bytes _claimData
     );
@@ -99,7 +99,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
 
     struct ProductSettings{
         OptimisticRebalanceParams optimisticParams;     // OptimisticRebalanceParams struct containing optimistic rebalance parameters.
-        bytes32 rulesHash;      // IPFS hash of the rules for the product.
+        string rulesHash;      // IPFS hash of the rules for the product.
     }
 
     /* ============ State Variables ============ */
@@ -182,7 +182,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
      */
     function setProductSettings(
         OptimisticRebalanceParams memory _optimisticParams,
-        bytes32 _rulesHash
+        string memory _rulesHash
     )
         external
         onlyOperator
@@ -232,7 +232,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
             _positionMultiplier
         ));
         require(assertionIds[proposalHash] == bytes32(0), "Proposal already exists");
-        require(productSettings.rulesHash != bytes32(""), "Rules not set");
+        require(bytes(productSettings.rulesHash).length > 0, "Rules not set");
         require(address(productSettings.optimisticParams.optimisticOracleV3) != address(0), "Oracle not set");
 
         bytes memory claim = _constructClaim(proposalHash, productSettings.rulesHash);
@@ -369,7 +369,7 @@ contract OptimisticAuctionRebalanceExtensionV1 is  AuctionRebalanceExtension, As
 
     // Constructs the claim that will be asserted at the Optimistic Oracle V3.
     // @dev Inspired by the equivalent function in the OptimisticGovernor: https://github.com/UMAprotocol/protocol/blob/96cf5be32a3f57ac761f004890dd3466c63e1fa5/packages/core/contracts/optimistic-governor/implementation/OptimisticGovernor.sol#L437
-    function _constructClaim(bytes32 proposalHash, bytes32 rulesHash) internal pure returns (bytes memory) {
+    function _constructClaim(bytes32 proposalHash, string memory rulesHash) internal pure returns (bytes memory) {
         return
             abi.encodePacked(
                 AncillaryData.appendKeyValueBytes32("", PROPOSAL_HASH_KEY, proposalHash),

--- a/test/adapters/optimisticAuctionRebalanceExtensionV1.spec.ts
+++ b/test/adapters/optimisticAuctionRebalanceExtensionV1.spec.ts
@@ -1,5 +1,6 @@
 import "module-alias/register";
 
+import base58 from "bs58";
 import { Address, Account } from "@utils/types";
 import { base58ToHexString } from "@utils/common";
 import { ADDRESS_ZERO, ZERO } from "@utils/constants";
@@ -28,6 +29,22 @@ import { BigNumber, ContractTransaction, utils, constants } from "ethers";
 
 const expect = getWaffleExpect();
 
+const decodeClaim = (claim: string) => {
+  const claimBytes = utils.arrayify(claim);
+
+  const firstPart = claimBytes.slice(0, 93);
+  const secondPart = claimBytes.slice(93, 93 + 32);
+  const thirdPart = claimBytes.slice(93 + 32);
+
+  // IPFS hash decoding, see: https://ethereum.stackexchange.com/questions/17094/how-to-store-ipfs-hash-using-bytes32
+  const sha2SelectorByte = 18;
+  const hashLengthByte = 32;
+  const encodedIPFSHash = utils.concat([[sha2SelectorByte, hashLengthByte], secondPart]);
+  const decodedIPFSHash = base58.encode(encodedIPFSHash);
+
+  return utils.toUtf8String(firstPart) + decodedIPFSHash + utils.toUtf8String(thirdPart);
+};
+
 describe("OptimisticAuctionRebalanceExtensionV1", () => {
   let owner: Account;
   let methodologist: Account;
@@ -51,6 +68,8 @@ describe("OptimisticAuctionRebalanceExtensionV1", () => {
 
   let useAssetAllowlist: boolean;
   let allowedAssets: Address[];
+
+  const ipfsHash = "Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z";
 
   before(async () => {
     [owner, methodologist, operator] = await getAccounts();
@@ -308,9 +327,7 @@ describe("OptimisticAuctionRebalanceExtensionV1", () => {
           let rulesHash: Uint8Array;
           let bondAmount: BigNumber;
           beforeEach(async () => {
-            rulesHash = utils.arrayify(
-              base58ToHexString("Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z"),
-            );
+            rulesHash = utils.arrayify(base58ToHexString(ipfsHash));
             bondAmount = ether(140); // 140 INDEX minimum bond
             await auctionRebalanceExtension.connect(operator.wallet).setProductSettings(
               {
@@ -532,6 +549,20 @@ describe("OptimisticAuctionRebalanceExtensionV1", () => {
                   expect(emittedRulesHash).to.eq(utils.hexlify(rulesHash));
                   const claim = assertEvent.args._claimData;
                   expect(claim).to.eq(constructClaim());
+                });
+
+                it("can decode the claim", async () => {
+                  const receipt = (await subject().then(tx => tx.wait())) as any;
+                  const assertEvent = receipt.events.find(
+                    (event: any) => event.event === "AssertedClaim",
+                  );
+                  const claim = assertEvent.args._claimData;
+                  const decodedClaim = decodeClaim(claim);
+                  const proposalHash = await auctionRebalanceExtension
+                    .connect(subjectCaller.wallet)
+                    .assertionIdToProposalHash(utils.formatBytes32String("win"));
+                  const expectedClaim = `proposalHash:${proposalHash.slice(2)},rulesIPFSHash:"${ipfsHash}"`;
+                  expect(decodedClaim).to.eq(expectedClaim);
                 });
 
                 context("when the same rebalance has been proposed already", () => {
@@ -891,9 +922,7 @@ describe("OptimisticAuctionRebalanceExtensionV1", () => {
                         identifier: utils.formatBytes32String(""),
                         optimisticOracleV3: optimisticOracleV3MockUpgraded.address,
                       },
-                      utils.arrayify(
-                        base58ToHexString("Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z"),
-                      ),
+                      utils.arrayify(base58ToHexString(ipfsHash)),
                     );
 
                     const proposalHash = await auctionRebalanceExtension

--- a/test/integration/ethereum/optimisticAuctionRebalanceExtenisonV1.spec.ts
+++ b/test/integration/ethereum/optimisticAuctionRebalanceExtenisonV1.spec.ts
@@ -3,7 +3,6 @@ import "module-alias/register";
 import { Address, Account } from "@utils/types";
 import { increaseTimeAsync } from "@utils/test";
 import { setBlockNumber } from "@utils/test/testingUtils";
-import { base58ToHexString } from "@utils/common";
 import { ONE_HOUR_IN_SECONDS, ZERO } from "@utils/constants";
 import { OptimisticAuctionRebalanceExtensionV1 } from "@utils/contracts/index";
 import {
@@ -168,7 +167,7 @@ if (process.env.INTEGRATIONTEST) {
             .connect(operator)
             .setProductSettings(
               productSettings,
-              utils.arrayify(base58ToHexString("Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z")),
+              "Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z",
             );
         });
 


### PR DESCRIPTION
While increasing gas costs, this makes decoding the whole claim a lot easier and fulfils the requirement of `ASSERT_TRUTH` claims to be utf8 decodable.