### PR TITLE
Improve subsidy handling

### DIFF
--- a/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
+++ b/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
@@ -402,23 +402,24 @@ if (process.env.INTEGRATIONTEST) {
                       wrappedSetTokenRedeemLiquidityMinAmount,
                     };
 
-                    const expectedSubsidy = await migrationExtension.callStatic.migrate(
+                    const [expectedSubsidy, expectedWrappedSetTokenPosition] = await migrationExtension.callStatic.migrate(
                       decodedParams,
                       underlyingLoanAmount,
                       maxSubsidy,
                       0,
                     );
 
-                    expect(expectedSubsidy).to.lt(maxSubsidy);
+                    expect(expectedWrappedSetTokenPosition).to.lt(maxSubsidy);
 
-                    const minSubsidy = expectedSubsidy.sub(ether(0.1));
+                    const minWrappedSetTokenPosition = expectedWrappedSetTokenPosition.sub(ether(0.001));
+                    console.log("expectedWrappedSetTokenPosition", utils.formatUnits(expectedWrappedSetTokenPosition, 18));
                     console.log("expectedSubsidy", utils.formatUnits(expectedSubsidy, 18));
 
                     await migrationExtension.migrate(
                       decodedParams,
                       underlyingLoanAmount,
                       maxSubsidy,
-                      minSubsidy,
+                      minWrappedSetTokenPosition,
                     );
                     const operatorWethBalanceAfter = await weth.balanceOf(
                       await operator.getAddress(),

--- a/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
+++ b/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
@@ -1,6 +1,6 @@
 import "module-alias/register";
 import { ethers } from "hardhat";
-import { BigNumber, Signer } from "ethers";
+import { BigNumber, Signer, utils } from "ethers";
 import { JsonRpcSigner } from "@ethersproject/providers";
 import { Account } from "@utils/types";
 import DeployHelper from "@utils/deploys";
@@ -404,10 +404,23 @@ if (process.env.INTEGRATIONTEST) {
                       wrappedSetTokenRedeemLiquidityMinAmount,
                     };
 
+                    const expectedSubsidy = await migrationExtension.callStatic.migrate(
+                      decodedParams,
+                      underlyingLoanAmount,
+                      maxSubsidy,
+                      0,
+                    );
+
+                    expect(expectedSubsidy).to.lt(maxSubsidy);
+
+                    const minSubsidy = expectedSubsidy.sub(ether(0.1));
+                    console.log("expectedSubsidy", utils.formatUnits(expectedSubsidy, 18));
+
                     await migrationExtension.migrate(
                       decodedParams,
                       underlyingLoanAmount,
                       maxSubsidy,
+                      minSubsidy,
                     );
                     const operatorWethBalanceAfter = await weth.balanceOf(
                       await operator.getAddress(),

--- a/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
+++ b/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
@@ -393,12 +393,12 @@ if (process.env.INTEGRATIONTEST) {
                       underlyingRedeemLiquidityMinAmount,
                       wrappedSetTokenRedeemLiquidityMinAmount,
                     };
-                    const expectedSubsidy = await migrationExtension.callStatic.migrate(
+                    const expectedOutput = await migrationExtension.callStatic.migrate(
                       decodedParams,
                       underlyingLoanAmount,
                       maxSubsidy
                     );
-                    expect(expectedSubsidy).to.lt(maxSubsidy);
+                    expect(expectedOutput).to.lt(maxSubsidy);
 
                     // Migrate atomically via Migration Extension
                     await migrationExtension.migrate(
@@ -409,7 +409,7 @@ if (process.env.INTEGRATIONTEST) {
 
                     // Verify operator WETH balance change
                     const operatorWethBalanceAfter = await weth.balanceOf(operatorAddress);
-                    expect(operatorWethBalanceBefore.sub(operatorWethBalanceAfter)).to.be.eq(expectedSubsidy);
+                    expect(operatorWethBalanceBefore.sub(operatorWethBalanceAfter)).to.be.gte(maxSubsidy.sub(expectedOutput));
 
                     // Verify ending components and units
                     const endingComponents = await eth2xfli.getComponents();

--- a/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
+++ b/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
@@ -325,7 +325,6 @@ if (process.env.INTEGRATIONTEST) {
                   let maxSubsidy: BigNumber;
                   let underlyingRedeemLiquidityMinAmount: BigNumber;
                   let wrappedSetTokenRedeemLiquidityMinAmount: BigNumber;
-                  let underlyingLoanAmountWithSubsidy: BigNumber;
 
                   let wethWhale: JsonRpcSigner;
 
@@ -352,7 +351,6 @@ if (process.env.INTEGRATIONTEST) {
                     // Flash loan parameters
                     underlyingLoanAmount = preciseMul(underlyingTradeUnits, setTokenTotalSupply);
 
-                    underlyingLoanAmountWithSubsidy = underlyingLoanAmount.add(maxSubsidy);
 
                     // Uniswap V3 liquidity parameters
                     underlyingSupplyLiquidityAmount = ZERO;

--- a/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
+++ b/test/integration/ethereum/aaveMigrationExtensionEth2x.spec.ts
@@ -351,7 +351,6 @@ if (process.env.INTEGRATIONTEST) {
                     // Flash loan parameters
                     underlyingLoanAmount = preciseMul(underlyingTradeUnits, setTokenTotalSupply);
 
-
                     // Uniswap V3 liquidity parameters
                     underlyingSupplyLiquidityAmount = ZERO;
                     wrappedSetTokenSupplyLiquidityAmount = preciseMul(
@@ -359,11 +358,6 @@ if (process.env.INTEGRATIONTEST) {
                       underlyingLoanAmount,
                     );
                     tokenId = await migrationExtension.tokenIds(0);
-                    exchangeName = "UniswapV3ExchangeAdapter";
-                    exchangeData = await uniswapV3ExchangeAdapter.generateDataParam(
-                      [tokenAddresses.weth, tokenAddresses.eth2x],
-                      [BigNumber.from(100)],
-                    );
                     underlyingRedeemLiquidityMinAmount = ZERO;
                     wrappedSetTokenRedeemLiquidityMinAmount = ZERO;
 
@@ -387,7 +381,7 @@ if (process.env.INTEGRATIONTEST) {
                     expect(startingComponents).to.deep.equal([tokenAddresses.weth]);
                     expect(startingUnit).to.eq(underlyingTradeUnits);
 
-                    // Migrate atomically via Migration Extension
+                    // Get the expected subsidy
                     const decodedParams = {
                       underlyingSupplyLiquidityAmount,
                       wrappedSetTokenSupplyLiquidityAmount,


### PR DESCRIPTION
1. Pull in subsidy instead of transfering in separate tx (requires approval)
2. Return net subsidy for use in simulation (callStatic)
3. Add min / maxSubsidy for additional slippage protection